### PR TITLE
Update to work with 0.16

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -195,7 +195,6 @@ end
 
 function placeLogiRailChest(wagon, chestName)
 	wagon.operable = false -- Don't want any changes to the wagon's inventory while it's copied over to the proxy chest
-	wagon.minable = false
 	local chest = wagon.surface.create_entity({name = chestName, position = wagon.position, force = wagon.force})
 	local chest_inventory = chest.get_inventory(defines.inventory.chest)
 	local wagon_inventory = wagon.get_inventory(defines.inventory.chest)
@@ -267,7 +266,6 @@ function prepareDeparture(wagon, chestName)
 		Inventory.copy_inventory(chest_inventory, wagon_inventory) -- Chest to wagon
 		chest.destroy()
 		wagon.operable = true
-		wagon.minable = true
 		removeChestToWagonLink(wagon)
 	end
 end

--- a/control.lua
+++ b/control.lua
@@ -1,5 +1,4 @@
 require "util"
-require "defines"
 require "stdlib/entity/inventory"
 
 local on_chest_created = nil
@@ -83,7 +82,7 @@ script.on_event(defines.events.on_robot_built_entity, function(event)
 	end
 end)
 
-script.on_event(defines.events.on_preplayer_mined_item, function(event)
+script.on_event(defines.events.on_pre_player_mined_item, function(event)
 	local entity = event.entity
 	if (entity.type == "cargo-wagon" or entity.type == "locomotive") and entity.train and entity.train.valid then
 		syncChests(entity.train)
@@ -116,7 +115,7 @@ end)
 
 script.on_event(defines.events.on_train_changed_state, function(event)
 	local train = event.train
-	if train.state == defines.trainstate.wait_station and train.speed == 0 then -- Trains only interact with the logistics network when they are waiting at a station in automatic mode
+	if train.state == defines.train_state.wait_station and train.speed == 0 then -- Trains only interact with the logistics network when they are waiting at a station in automatic mode
 		placeChests(train)
 	else
 		syncChests(train)
@@ -275,7 +274,7 @@ function syncChests(train)
 			prepareDeparture(wagon, "passive-provider-chest-from-wagon")
 			prepareDeparture(wagon, "active-provider-chest-from-wagon")
 			prepareDeparture(wagon, "storage-chest-from-wagon")
-			game.raise_event(on_chest_destroyed, {wagon_index=i, train=train})
+			script.raise_event(on_chest_destroyed, {wagon_index=i, train=train})
 		end
 	end
 end

--- a/info.json
+++ b/info.json
@@ -4,6 +4,7 @@
   "title": "Logistics Railway",
   "author": "Supercheese",
   "homepage": "https://forums.factorio.com/viewtopic.php?f=93&t=21462",
-  "dependencies": ["base >= 0.12.17"],
+  "factorio_version": "0.16",
+  "dependencies": ["base"],
   "description": "Turn your regular, boring old trains into Logistics Trains! Now your bots can load and unload directly into your cargo wagons -- no inserters needed!"
 }

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "Logistics Railway",
-  "version": "1.0.8",
+  "version": "1.0.10",
   "title": "Logistics Railway",
   "author": "Supercheese",
   "homepage": "https://forums.factorio.com/viewtopic.php?f=93&t=21462",

--- a/prototypes/entities.lua
+++ b/prototypes/entities.lua
@@ -4,7 +4,7 @@ data:extend({
     name = "storage-chest-from-wagon",
     icon = "__base__/graphics/icons/logistic-chest-storage.png",
     flags = {"placeable-neutral", "placeable-off-grid"},
-    max_health = 0,
+    max_health = 1,
     corpse = "small-remnants",
     collision_box = {{-0.35, -0.35}, {0.35, 0.35}},
     selection_box = {{-0.2, -0.2}, {0.2, 0.2}},
@@ -22,14 +22,15 @@ data:extend({
       height = 1,
       shift = {0, 0}
     },
-    circuit_wire_max_distance = 0
+    circuit_wire_max_distance = 0,
+    icon_size = 32
   },
   {
     type = "logistic-container",
     name = "passive-provider-chest-from-wagon",
     icon = "__base__/graphics/icons/logistic-chest-passive-provider.png",
     flags = {"placeable-neutral", "placeable-off-grid"},
-    max_health = 0,
+    max_health = 1,
     corpse = "small-remnants",
     collision_box = {{-0.35, -0.35}, {0.35, 0.35}},
     selection_box = {{-0.2, -0.2}, {0.2, 0.2}},
@@ -47,14 +48,15 @@ data:extend({
       height = 1,
       shift = {0, 0}
     },
-    circuit_wire_max_distance = 0
+    circuit_wire_max_distance = 0,
+    icon_size = 32
   },
   {
     type = "logistic-container",
     name = "active-provider-chest-from-wagon",
     icon = "__base__/graphics/icons/logistic-chest-active-provider.png",
     flags = {"placeable-neutral", "placeable-off-grid"},
-    max_health = 0,
+    max_health = 1,
     corpse = "small-remnants",
     collision_box = {{-0.35, -0.35}, {0.35, 0.35}},
     selection_box = {{-0.2, -0.2}, {0.2, 0.2}},
@@ -72,14 +74,16 @@ data:extend({
       height = 1,
       shift = {0, 0}
     },
-    circuit_wire_max_distance = 0
+    circuit_wire_max_distance = 0,
+    icon_size = 32
   },
   {
     type = "logistic-container",
     name = "requester-chest-from-wagon",
     icon = "__base__/graphics/icons/logistic-chest-requester.png",
     flags = {"placeable-neutral", "placeable-off-grid"},
-    max_health = 0,
+    max_health = 1,
+    logistic_slots_count = 12,
     corpse = "small-remnants",
     collision_box = {{-0.35, -0.35}, {0.35, 0.35}},
     selection_box = {{-0.2, -0.2}, {0.2, 0.2}},
@@ -97,21 +101,23 @@ data:extend({
       height = 1,
       shift = {0, 0}
     },
-    circuit_wire_max_distance = 0
+    circuit_wire_max_distance = 0,
+    icon_size = 32
   },
   {
     type = "logistic-container",
     name = "requester-rail-dummy-chest",
     icon = "__base__/graphics/icons/logistic-chest-requester.png",
     flags = {"placeable-neutral", "placeable-off-grid"},
-	minable = {hardness = 0.2, mining_time = 0.5, result = "straight-rail"},
-    max_health = 0,
+	minable = {hardness = 0.2, mining_time = 0.5, result = "rail"},
+    max_health = 1,
     corpse = "small-remnants",
     collision_box = {{-0.99999, -0.99999}, {0.99999, 0.99999}},
     selection_box = {{-1.25, -1.25}, {1.25, 1.25}},
 	collision_mask = {"not-colliding-with-itself"},
 	order = "z",
     inventory_size = 1,
+    logistic_slots_count = 12,
     logistic_mode = "requester",
     picture =
     {
@@ -121,7 +127,8 @@ data:extend({
       height = 1,
       shift = {0, 0}
     },
-    circuit_wire_max_distance = 0
+    circuit_wire_max_distance = 0,
+    icon_size = 32
   },
 })
 

--- a/prototypes/items.lua
+++ b/prototypes/items.lua
@@ -6,7 +6,8 @@ data:extend({
 	flags = {"hidden"},
 	subgroup = "transport",
 	order = "z",
-	stack_size = 1
+	stack_size = 1,
+	icon_size = 32
 },
 {
 	type = "item",
@@ -16,7 +17,8 @@ data:extend({
 	subgroup = "transport",
 	order = "a[train-system]-b[rail-storage]",
 	place_result = "storage-rail",
-	stack_size = 100
+	stack_size = 100,
+	icon_size = 32
 },
 {
 	type = "item",
@@ -26,7 +28,8 @@ data:extend({
 	subgroup = "transport",
 	order = "a[train-system]-b[rail-passive-provider]",
 	place_result = "passive-provider-rail",
-	stack_size = 100
+	stack_size = 100,
+	icon_size = 32
 },
 {
 	type = "item",
@@ -36,7 +39,8 @@ data:extend({
 	subgroup = "transport",
 	order = "a[train-system]-b[rail-active-provider]",
 	place_result = "active-provider-rail",
-	stack_size = 100
+	stack_size = 100,
+	icon_size = 32
 },
 {
 	type = "item",
@@ -46,6 +50,7 @@ data:extend({
 	subgroup = "transport",
 	order = "a[train-system]-b[rail-requester]",
 	place_result = "requester-rail",
-	stack_size = 100
+	stack_size = 100,
+	icon_size = 32
 },
 })

--- a/prototypes/rails.lua
+++ b/prototypes/rails.lua
@@ -8,6 +8,7 @@ passive_provider_rail.name = "passive-provider-rail"
 active_provider_rail.name = "active-provider-rail"
 requester_rail.name = "requester-rail"
 
+data.raw["straight-rail"]["straight-rail"].fast_replaceable_group = "rails"
 storage_rail.fast_replaceable_group = "rails"
 passive_provider_rail.fast_replaceable_group = "rails"
 active_provider_rail.fast_replaceable_group = "rails"

--- a/prototypes/rails.lua
+++ b/prototypes/rails.lua
@@ -26,16 +26,16 @@ requester_rail.collision_box = {{-0.7, -0.99999}, {0.7, 0.99999}}
 -- requester_rail.selection_box = {{-0.1, -0.1}, {0.1, 0.1}} -- This doesn't seem to actually work
 
 storage_rail.pictures.straight_rail_vertical.metals.tint = { r = 1.0, g = 1.0, b = 0.0, a = 0.5 }
-storage_rail.pictures.straight_rail_diagonal.metals.tint = { r = 1.0, g = 1.0, b = 0.0, a = 0.5 }
+-- storage_rail.pictures.straight_rail_diagonal.metals.tint = { r = 1.0, g = 1.0, b = 0.0, a = 0.5 }
 storage_rail.pictures.straight_rail_horizontal.metals.tint = { r = 1.0, g = 1.0, b = 0.0, a = 0.5 }
 passive_provider_rail.pictures.straight_rail_vertical.metals.tint = { r = 1.0, g = 0.0, b = 0.0, a = 0.5 }
-passive_provider_rail.pictures.straight_rail_diagonal.metals.tint = { r = 1.0, g = 0.0, b = 0.0, a = 0.5 }
+-- passive_provider_rail.pictures.straight_rail_diagonal.metals.tint = { r = 1.0, g = 0.0, b = 0.0, a = 0.5 }
 passive_provider_rail.pictures.straight_rail_horizontal.metals.tint = { r = 1.0, g = 0.0, b = 0.0, a = 0.5 }
 active_provider_rail.pictures.straight_rail_vertical.metals.tint = { r = 1.0, g = 0.0, b = 1.0, a = 0.5 }
-active_provider_rail.pictures.straight_rail_diagonal.metals.tint = { r = 1.0, g = 0.0, b = 1.0, a = 0.5 }
+-- active_provider_rail.pictures.straight_rail_diagonal.metals.tint = { r = 1.0, g = 0.0, b = 1.0, a = 0.5 }
 active_provider_rail.pictures.straight_rail_horizontal.metals.tint = { r = 1.0, g = 0.0, b = 1.0, a = 0.5 }
 requester_rail.pictures.straight_rail_vertical.metals.tint = { r = 0.0, g = 0.0, b = 1.0, a = 0.5 }
-requester_rail.pictures.straight_rail_diagonal.metals.tint = { r = 0.0, g = 0.0, b = 1.0, a = 0.5 }
+-- requester_rail.pictures.straight_rail_diagonal.metals.tint = { r = 0.0, g = 0.0, b = 1.0, a = 0.5 }
 requester_rail.pictures.straight_rail_horizontal.metals.tint = { r = 0.0, g = 0.0, b = 1.0, a = 0.5 }
 
 data:extend({storage_rail, passive_provider_rail, active_provider_rail, requester_rail})

--- a/prototypes/recipes.lua
+++ b/prototypes/recipes.lua
@@ -5,7 +5,7 @@ data:extend({
     enabled = "false",
     ingredients =
     {
-      {"straight-rail", 1},
+      {"rail", 1},
     },
     result = "storage-rail"
 },
@@ -15,7 +15,7 @@ data:extend({
     enabled = "false",
     ingredients =
     {
-      {"straight-rail", 1},
+      {"rail", 1},
     },
     result = "passive-provider-rail"
 },
@@ -25,7 +25,7 @@ data:extend({
     enabled = "false",
     ingredients =
     {
-      {"straight-rail", 1},
+      {"rail", 1},
     },
     result = "active-provider-rail"
 },
@@ -35,7 +35,7 @@ data:extend({
     enabled = "false",
     ingredients =
     {
-      {"straight-rail", 1},
+      {"rail", 1},
     },
     result = "requester-rail"
 },

--- a/prototypes/technologies.lua
+++ b/prototypes/technologies.lua
@@ -3,7 +3,7 @@ data:extend({
     type = "technology",
     name = "logistics-wagons",
     icon = "__Logistics Railway__/graphics/logistics-trains.png",
-	icon_size = 128,
+    icon_size = 128,
     effects =
     {
       {


### PR DESCRIPTION
fixes #8
Built upon the work from ekle to make the mod work again in 0.16.

So the issue was the wait for empty/full commands not being compatible with this mod.
So to fix it the content of the logistic chest attached to a wagon copies its content to the wagon once a second. So when the logistic chest is full, the wagon is full and when it's empty the wagon is also empty.
This should fix all wait commands including the circuit network ones. 